### PR TITLE
Added plugin system and fixed cursor pos patch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,24 +6,24 @@
     <PropertyGroup>
         <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
         <TestLibrary>false</TestLibrary>
+        <ModInstallDir>$(USERPROFILE)\Documents\Klei\OxygenNotIncluded\mods\Dev\MPNI</ModInstallDir>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
         <DefineConstants>TRACE;DEBUG</DefineConstants>
-        <OutputPath>$(USERPROFILE)\Documents\Klei\OxygenNotIncluded\mods\Dev\MPNI</OutputPath>
+        <OutputPath>$(ModInstallDir)</OutputPath>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DefineConstants>TRACE;RELEASE</DefineConstants>
-        <OutputPath>$(USERPROFILE)\Documents\Klei\OxygenNotIncluded\mods\Dev\MPNI</OutputPath>
+        <OutputPath>$(ModInstallDir)</OutputPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^MPNI.Core$'))">
         <UnityModLibrary>true</UnityModLibrary>
     </PropertyGroup>
     <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^MPNI\..*$'))">
-        <MPNILibrary>true</MPNILibrary>
+        <OutputPath>$(ModInstallDir)\bin</OutputPath>
     </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(MPNILibrary)' == 'true' ">
-        <OutputPath>$(USERPROFILE)\Documents\Klei\OxygenNotIncluded\mods\Dev\MPNI\bin</OutputPath>
+    <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^MPNI\.Plugin\..*$'))">
+        <OutputPath>$(ModInstallDir)\bin\plugins</OutputPath>
     </PropertyGroup>
 </Project>

--- a/MPNI.Core/MPNI.Core.csproj
+++ b/MPNI.Core/MPNI.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -32,17 +32,21 @@
             <HintPath>$(ONIManaged)\0Harmony.dll</HintPath>
             <Private>false</Private>
         </Reference>
-        <Reference Include="System"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Xml"/>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="Patcher.cs"/>
-        <Compile Include="Patches\Abstract\ONIPatch.cs"/>
-        <Compile Include="Patches\CameraController_Update_Patch.cs"/>
-        <Compile Include="Properties\AssemblyInfo.cs"/>
-        <Compile Include="Steam\SteamManager.cs"/>
+        <Compile Include="Patcher.cs" />
+        <Compile Include="Patches\Abstract\ONIPatch.cs" />
+        <Compile Include="Patches\CameraController_Update_Patch.cs" />
+        <Compile Include="Plugins\Api\Events\MouseMoveEventArgs.cs" />
+        <Compile Include="Plugins\Api\Logger.cs" />
+        <Compile Include="Plugins\Api\Mouse.cs" />
+        <Compile Include="Plugins\IPlugin.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="Steam\SteamManager.cs" />
     </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MPNI.Core/Patcher.cs
+++ b/MPNI.Core/Patcher.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Harmony;
 using MPNI.Core.Patches.Abstract;
+using MPNI.Core.Plugins;
+using static MPNI.Core.Plugins.Api.Logger;
 
 namespace MPNI.Core
 {
@@ -12,20 +15,50 @@ namespace MPNI.Core
         public static void Execute()
         {
             PatchAll(HarmonyInstance.Create("MPNI"));
+            LoadPlugins();
         }
 
-        public static void PatchAll(HarmonyInstance instance)
+        private static void PatchAll(HarmonyInstance instance)
         {
             IEnumerable<Type> patches = Assembly.GetExecutingAssembly().GetTypes().Where(t => typeof(ONIPatch).IsAssignableFrom(t) && !t.IsAbstract);
 
-            Console.WriteLine("[MPNI] Applying patches");
+            Log("Applying patches");
             foreach (Type type in patches)
             {
                 ONIPatch patch = (ONIPatch)Activator.CreateInstance(type);
-                Console.WriteLine($"[MPNI] Patch: {type.FullName}");
+                Log($"Patch: {type.FullName}");
                 patch.Patch(instance);
             }
-            Console.WriteLine("[MPNI] Patching finished");
+            Log("Patching finished");
+        }
+
+        private static void LoadPlugins()
+        {
+            string pluginDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "plugins");
+            Log("Loading plugins");
+            int pluginsLoaded = 0;
+            foreach (var dll in Directory.GetFileSystemEntries(pluginDir, "*.dll", SearchOption.TopDirectoryOnly))
+            {
+                var plugin = Assembly.Load(dll);
+                foreach (var pluginType in plugin.GetTypes().Where(t => !t.IsAbstract && typeof(IPlugin).IsAssignableFrom(t)))
+                {
+                    try
+                    {
+                        var pluginInstance = Activator.CreateInstance(pluginType) as IPlugin;
+                        if (pluginInstance != null)
+                        {
+                            pluginInstance.Start();
+                            Log(pluginType.FullName);
+                        }
+                        pluginsLoaded++;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log($"Error loading plugin '{pluginType}':{Environment.NewLine}{ex}");
+                    }
+                }
+            }
+            Log($"Loaded {pluginsLoaded} plugins");
         }
     }
 }

--- a/MPNI.Core/Patches/Abstract/ONIPatch.cs
+++ b/MPNI.Core/Patches/Abstract/ONIPatch.cs
@@ -47,7 +47,7 @@ namespace MPNI.Core.Patches.Abstract
         {
             if (targetMethod == null)
             {
-                throw new ArgumentNullException("targetMethod");
+                throw new ArgumentNullException(nameof(targetMethod));
             }
 
             HarmonyMethod harmonyPrefixMethod = prefixMethod != null ? GetHarmonyMethod(prefixMethod) : null;

--- a/MPNI.Core/Patches/CameraController_Update_Patch.cs
+++ b/MPNI.Core/Patches/CameraController_Update_Patch.cs
@@ -1,23 +1,33 @@
-﻿using Harmony;
+﻿using System.Reflection;
+using Harmony;
 using MPNI.Core.Patches.Abstract;
+using MPNI.Core.Plugins.Api;
+using MPNI.Core.Plugins.Api.Events;
 using UnityEngine;
 
 namespace MPNI.Core.Patches
 {
     internal class CameraController_Update_Patch : ONIPatch
     {
-        private static float targetTime;
+        private static readonly MethodInfo TargetMethod =
+            typeof(CameraController).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private static MouseMoveEventArgs lastMoveEvent;
+
         public static void Postfix()
         {
-            if (Time.deltaTime > targetTime)
+            var cursorPos = Shader.GetGlobalVector("_WorldCursorPos");
+            var moveEvent = new MouseMoveEventArgs(cursorPos.x, cursorPos.y);
+            if (lastMoveEvent != moveEvent)
             {
-                Vector4 cursorPos = Shader.GetGlobalVector("_WorldCursorPos");
-                targetTime = Time.deltaTime + 0.02f;
+                Mouse.OnMoved(moveEvent);
+                lastMoveEvent = moveEvent;
             }
         }
 
         public override void Patch(HarmonyInstance harmony)
         {
+            PatchPostfix(harmony, TargetMethod);
         }
     }
 }

--- a/MPNI.Core/Plugins/Api/Events/MouseMoveEventArgs.cs
+++ b/MPNI.Core/Plugins/Api/Events/MouseMoveEventArgs.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace MPNI.Core.Plugins.Api.Events
+{
+    public class MouseMoveEventArgs : EventArgs
+    {
+        public MouseMoveEventArgs(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public float X { get; }
+        public float Y { get; }
+
+        protected bool Equals(MouseMoveEventArgs other)
+        {
+            return X.Equals(other.X) && Y.Equals(other.Y);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((MouseMoveEventArgs) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(MouseMoveEventArgs left, MouseMoveEventArgs right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(MouseMoveEventArgs left, MouseMoveEventArgs right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/MPNI.Core/Plugins/Api/Logger.cs
+++ b/MPNI.Core/Plugins/Api/Logger.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace MPNI.Core.Plugins.Api
+{
+    public static class Logger
+    {
+        public static void Log(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+            Console.WriteLine($"[MPNI] {message}");
+        }
+    }
+}

--- a/MPNI.Core/Plugins/Api/Mouse.cs
+++ b/MPNI.Core/Plugins/Api/Mouse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using MPNI.Core.Plugins.Api.Events;
+
+namespace MPNI.Core.Plugins.Api
+{
+    public static class Mouse
+    {
+        public static event EventHandler<MouseMoveEventArgs> Moved;
+
+        internal static void OnMoved(MouseMoveEventArgs e)
+        {
+            Moved?.Invoke(null, e);
+        }
+    }
+}

--- a/MPNI.Core/Plugins/IPlugin.cs
+++ b/MPNI.Core/Plugins/IPlugin.cs
@@ -1,0 +1,7 @@
+﻿namespace MPNI.Core.Plugins
+{
+    public interface IPlugin
+    {
+        void Start();
+    }
+}

--- a/MPNI.Plugin.Multiplayer/MPNI.Plugin.Multiplayer.csproj
+++ b/MPNI.Plugin.Multiplayer/MPNI.Plugin.Multiplayer.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>MPNI.Plugin.Multiplayer</RootNamespace>
+        <AssemblyName>MPNI.Plugin.Multiplayer</AssemblyName>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="System"/>
+        <Reference Include="System.Core"/>
+        <Reference Include="System.Data"/>
+        <Reference Include="System.Xml"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Plugin.cs"/>
+        <Compile Include="Properties\AssemblyInfo.cs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\MPNI.Core\MPNI.Core.csproj">
+            <Project>{9491a684-0845-4f90-9ebb-140c5472864e}</Project>
+            <Name>MPNI.Core</Name>
+            <Private>false</Private>
+        </ProjectReference>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+</Project>

--- a/MPNI.Plugin.Multiplayer/Plugin.cs
+++ b/MPNI.Plugin.Multiplayer/Plugin.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using MPNI.Core.Plugins;
+using MPNI.Core.Plugins.Api;
+
+namespace MPNI.Plugin.Multiplayer
+{
+    public class Plugin : IPlugin
+    {
+        public void Start()
+        {
+            Mouse.Moved += (sender, args) =>
+            {
+                Console.WriteLine($"Mouse moved: {args.X}, {args.Y}");
+            };
+        }
+    }
+}

--- a/MPNI.Plugin.Multiplayer/Properties/AssemblyInfo.cs
+++ b/MPNI.Plugin.Multiplayer/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MPNI.Plugin.Multiplayer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MPNI.Plugin.Multiplayer")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("AE6BC3F3-9751-461C-84E8-0897D8CEE5A5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MPNI.sln
+++ b/MPNI.sln
@@ -15,6 +15,8 @@ EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MPNI.Core", "MPNI.Core\MPNI.Core.csproj", "{9491A684-0845-4F90-9EBB-140C5472864E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MPNI.Plugin.Multiplayer", "MPNI.Plugin.Multiplayer\MPNI.Plugin.Multiplayer.csproj", "{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{9491A684-0845-4F90-9EBB-140C5472864E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9491A684-0845-4F90-9EBB-140C5472864E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9491A684-0845-4F90-9EBB-140C5472864E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE6BC3F3-9751-461C-84E8-0897D8CEE5A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MPNI/Mod_OnLoad.cs
+++ b/MPNI/Mod_OnLoad.cs
@@ -11,14 +11,21 @@ namespace MPNI
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
             AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += CurrentDomainOnAssemblyResolve;
 
-            var assembly = Assembly.Load(new AssemblyName("MPNI.Core"));
-            assembly.GetType("MPNI.Core.Patcher")
-                .InvokeMember("Execute",
-                    BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod,
-                    null,
-                    null,
-                    null);
-            Log("Loaded");
+            try
+            {
+                var assembly = Assembly.Load(new AssemblyName("MPNI.Core"));
+                assembly.GetType("MPNI.Core.Patcher")
+                    .InvokeMember("Execute",
+                        BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod,
+                        null,
+                        null,
+                        null);
+            }
+            catch (Exception)
+            {
+                Log("Failed to initializes");
+                throw;
+            }
         }
 
         private static Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args)


### PR DESCRIPTION
Solution is now as follows:
 - MPNI: Loads MPNI.Core
 - MPNI.Core: 
    - Patches the game
    - Sends game data to internally defined API
    - Loads plugins in "plugins" subdir and calls `Plugin.Start`.
 - MPNI.Plugin.Multiplayer: Only references MPNI.Core and uses its API to read/write game state.

PS: CameraController patch works but the `Shader.GetGlobalVar` ~gives strange results (all in-between 50-200 position range).~ Nvm it's the tile index in the world but it can go negative as well based on where the camera is.